### PR TITLE
Adding COI version 1.0

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -571,7 +571,7 @@ sim_epi <- function(project,
                     "Sv", "Ev", "Iv",
                     "EIR",
                     "A_detectable_microscopy", "C_detectable_microscopy",
-                    "A_detectable_PCR", "C_detectable_PCR")
+                    "A_detectable_PCR", "C_detectable_PCR","n_inoc")
     return(ret)
   }, 1:length(output_raw$daily_values), SIMPLIFY = FALSE)
   daily_values <- do.call(rbind, daily_values_list)

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -65,6 +65,9 @@ void Dispatcher::init() {
   Ah_detectable_PCR = vector<double>(n_demes);
   Ch_detectable_PCR = vector<double>(n_demes);
   
+  // number of active inoculations
+  n_inoc = vector<double>(n_demes);
+  
   // initialise single population of human hosts over all demes. This is
   // preferable to using separate vectors of hosts for each deme, as this would
   // mean moving hosts around due to migration. With a single population we can
@@ -187,6 +190,7 @@ void Dispatcher::run_simulation(Rcpp::List &args_functions, Rcpp::List &args_pro
         
         // get number of new infectious bites on humans
         EIR[k] = a*Iv[k]/double(H[k]);
+       
         double prob_infectious_bite = 1 - exp(-EIR[k]);  // probability of new infectious bite on host
         
         // one method of drawing infections in humans would be to draw the total
@@ -338,6 +342,8 @@ void Dispatcher::run_simulation(Rcpp::List &args_functions, Rcpp::List &args_pro
     
     //-------- STORE RESULTS --------
     
+  
+    
     // update counts of each host status in each deme
     update_host_counts(t);
     
@@ -347,9 +353,9 @@ void Dispatcher::run_simulation(Rcpp::List &args_functions, Rcpp::List &args_pro
                             double(Sv[k]), double(Ev[k]), double(Iv[k]),
                             EIR[k],
                             Ah_detectable_microscopy[k], Ch_detectable_microscopy[k],
-                            Ah_detectable_PCR[k], Ch_detectable_PCR[k]};
+                            Ah_detectable_PCR[k], Ch_detectable_PCR[k],n_inoc[k]};
     }
-    
+
     // store age distributions
     if (output_age_distributions && output_age_times[index_age_distributions] == t+1) {
       
@@ -407,10 +413,12 @@ void Dispatcher::update_host_counts(int t) {
   fill(Ch_detectable_microscopy.begin(), Ch_detectable_microscopy.end(), 0.0);
   fill(Ah_detectable_PCR.begin(), Ah_detectable_PCR.end(), 0.0);
   fill(Ch_detectable_PCR.begin(), Ch_detectable_PCR.end(), 0.0);
-  
+  fill(n_inoc.begin(),n_inoc.end(), 0.0);
   // loop through all hosts, update counts in given deme
   for (unsigned int i = 0; i < host_pop.size(); ++i) {
     int this_deme = host_pop[i].deme;
+    n_inoc[this_deme] += host_pop[i].get_n_active_inoc();
+    
     switch(host_pop[i].get_host_status()) {
     case Host_Sh:
       Sh[this_deme]++;

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -76,6 +76,8 @@ public:
   // misc
   std::vector<double> EIR;
   
+  // number of active inoculations
+  std::vector<double> n_inoc;
   
   // PUBLIC FUNCTIONS
   

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -320,6 +320,7 @@ void Host::denovo_infection(int t, int &next_inoc_ID, std::ofstream &transmissio
 // infection
 void Host::infection(int t, int &next_inoc_ID, Mosquito &mosq, std::ofstream &transmission_record) {
   
+  //print(get_n_active_inoc());
   // return if already at max_inoculations
   if (get_n_active_inoc() == max_inoculations) {
     infection_index++;
@@ -441,6 +442,7 @@ void Host::infection(int t, int &next_inoc_ID, Mosquito &mosq, std::ofstream &tr
   // update indices
   infection_index++;
   inoc_index++;
+  //print(inoc_index);
   
   // print to transmission record
   if (save_transmission_record) {


### PR DESCRIPTION
Edited code to output total active inoculations (n_inoc) per time point as an additional column in the daily counts output. Mean MOI can be calculated from this by dividing n_inoc by the total number of E, A and C state individuals at that timepoint. Worth noting this doesn't currently allow for obtaining the distribution of MOI, which may be interesting to add.